### PR TITLE
fix _calloc_r to return the properly-sized, zeroed memory

### DIFF
--- a/newlib_port.c
+++ b/newlib_port.c
@@ -236,5 +236,5 @@ void* _realloc_r(struct _reent *rptr, void* ptr, size_t size) {
 void* _calloc_r(struct _reent *rptr, size_t num, size_t size) {
     void *ptr = os_malloc(num * size);
     os_bzero(ptr, num * size);
-    return os_malloc(size);
+    return ptr;
 }


### PR DESCRIPTION
Previously it would os_malloc the proper amount, zero it, and then return a fresh os_malloc which did not take num into account.

I suspect this was a simple copy-paste error.
